### PR TITLE
Use Equity and Triplicate

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -23,6 +23,7 @@
     <meta name="msapplication-TileColor"    content="#da532c">
     <meta name="msapplication-TileImage"    content="RELEASE/favicons/mstile-144x144.png">
     <meta name="theme-color"                content="#ffffff">
+    <link rel=stylesheet href=https://commonform.org/fonts.css>
     <link rel=stylesheet href=RELEASE/normalize.css>
     <link rel=stylesheet href=RELEASE/styles.css>
   </head>

--- a/styles.sass
+++ b/styles.sass
@@ -43,7 +43,7 @@
 
 body
   text-align: center
-  font-family: "Century Schoolbook", Georgia
+  font-family: Equity, Georgia, serif
   color: #444
   text-rendering: optimizeLegibility
 
@@ -70,7 +70,7 @@ body
 
 .commonform
   .digest
-    font-family: "Andale Mono"
+    font-family: Triplicate, "Andale Mono", monospace
     font-size: 75%
 
   header,


### PR DESCRIPTION
@mbutterick: Thanks so much for allowing our humble project to use your beautiful typefaces!

I for one so look forward to seeing your type on commonform.org each day, having become accustomed to that luxury in my personal documents.

As we discussed separately, I've not checked any copy of the WOFFs themselves into this repository, but instead `<link>`ed a static copy: https://commonform.org/fonts.css

A comment at the top of the CSS file with the WOFFs reads:

``` css
/* Equity and Triplicate typefaces are (c) Matthew Butterick.
   Used with permission.
   These fonts are /not/ free for you to use or distribute. */
```

Of course, if you would prefer different wording in the comment, I will be happy to update.

You may notice that CommonForm.org does _not_ presently display "educated" quotations marks and other typographic niceties Unicode permits. Common Form permits only ASCII characters in its data, to limit cases where we have two forms that read the same, but hash differently. @anseljh have done a bit of work on "educating" quotation marks and other punctuation with software. I imagine we'll eventually settle on a 99% good solution, but have learned there are edge cases that make a perfect algorithm very hard or impossible.

All the same, I will follow up with a tiny PR to mention your name and the names of your typefaces, so that others less familiar will have some way to follow bread crumbs back to your website.
