### PR TITLE
Display typographers' quotes

### DIFF
--- a/renderers/annotations.js
+++ b/renderers/annotations.js
@@ -1,16 +1,18 @@
 module.exports = annotations
 
 var h = require('virtual-dom/h')
+var improvePunctuation = require('../utility/improve-punctuation')
 
 function annotations(annotations) {
   return h('aside', deduplicate(annotations).map(annotation)) }
 
 function annotation(annotation) {
+  var message = improvePunctuation(annotation.message)
   return h('p.',
     { className: annotation.level },
     [ ( annotation.url ?
-          ('a', { href: annotation.url }, annotation.message) :
-          annotation.message ) ]) }
+          h('a', { href: annotation.url }, message) :
+          message ) ]) }
 
 function deduplicate(annotations) {
   return annotations

--- a/renderers/text.js
+++ b/renderers/text.js
@@ -1,6 +1,7 @@
 module.exports = text
 
 var h = require('virtual-dom/h')
+var improvePunctuation = require('../utility/improve-punctuation')
 
 function text(text) {
-  return h('span', text) }
+  return h('span', improvePunctuation(text)) }

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -97,7 +97,33 @@ tape('Browser', function(test) {
             !existing,
             'On clicking "Add Signature Page" ' +
             'and then "Delete this Signature Page", '+
-            'the text "Signature Page Follows" disappears.') }) }) }) })
+            'the text "Signature Page Follows" disappears.') }) }) })
+
+    test.test(function(test) {
+      test.plan(1)
+      var hash = (
+        'd68564fa22da73d2bb989207d4973ec7' +
+        '366da62b612f63f65eaa8e2a2281222d' )
+      webdriver
+        .url('http://localhost:8000/forms/' + hash)
+        .isExisting('//*[contains(text(),"Wouldn’t")]')
+        .then(function(existing) {
+          test.assert(
+            existing,
+            'Displays "Wouldn’t" with nice quote.') }) })
+
+    test.test(function(test) {
+      test.plan(1)
+      var hash = (
+        'd68564fa22da73d2bb989207d4973ec7' +
+        '366da62b612f63f65eaa8e2a2281222d' )
+      webdriver
+        .url('http://localhost:8000/forms/' + hash)
+        .isExisting('//*[contains(text(),"“quotation marks”")]')
+        .then(function(existing) {
+          test.assert(
+            existing,
+            'Displays “quotation marks” with nice quotes.') }) }) })
 
 tape.onFinish(function() {
   webdriver.end() })

--- a/test/fixtures/typographers-quotes.json
+++ b/test/fixtures/typographers-quotes.json
@@ -1,0 +1,1 @@
+{ "content": [ "Wouldn't it be grand if \"quotation marks\" were displayed correctly?" ] }

--- a/utility/improve-punctuation.js
+++ b/utility/improve-punctuation.js
@@ -1,0 +1,19 @@
+module.exports = improvePunctuation
+
+var LEFT_DOUBLE = '“'
+var RIGHT_DOUBLE = '”'
+var RIGHT_SINGLE = '’'
+
+var replacements = [
+  [ /^"/g, LEFT_DOUBLE ],
+  [ /"$/g, RIGHT_DOUBLE ],
+  [ / "/g, ( ' ' + LEFT_DOUBLE ) ],
+  [ /"/g,  RIGHT_DOUBLE ],
+  [ /'/g,  RIGHT_SINGLE] ]
+
+function improvePunctuation(string) {
+  return replacements
+    .reduce(
+      function(returned, replacement) {
+        return returned.replace(replacement[0], replacement[1]) },
+      string) }


### PR DESCRIPTION
This PR adds naive logic for converting ASCII quotes to Unicode typographers' quotes. I'd guess it will correctly display >99% of all text in existing forms.

The primary motivation is to do less insult to @mbutterick's type. There is much more to be done there.
