### PR TITLE
Add "Download Markup" Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "commonform-docx": "^0.11.3",
     "commonform-group-series": "^0.5.1",
     "commonform-lint": "^0.6.2",
+    "commonform-markup-stringify": "^0.1.0",
     "commonform-merkleize": "^0.3.2",
     "commonform-predicate": "^0.4.3",
     "commonform-treeify-annotations": "^0.1.1",

--- a/renderers/docx-button.js
+++ b/renderers/docx-button.js
@@ -1,4 +1,4 @@
-module.exports = downloadButton
+module.exports = docxButton
 
 var clone = require('../utility/json-clone')
 var docx = require('commonform-docx')
@@ -7,7 +7,7 @@ var h = require('virtual-dom/h')
 var outline = require('outline-numbering')
 var signaturePages = require('ooxml-signature-pages')
 
-function downloadButton(state) {
+function docxButton(state) {
   var form = state.form
   var blanks = state.blanks
   var signatures = state.signatures
@@ -27,7 +27,7 @@ function downloadButton(state) {
             docx(clone(form), blanks, options)
               .generate({ type: 'blob' }),
             fileName(title, 'docx')) } } },
-    [ 'Download' ]) }
+    [ 'Download for Word' ]) }
 
 function fileName(title, extension) {
   var date = new Date().toISOString()

--- a/renderers/index.js
+++ b/renderers/index.js
@@ -20,7 +20,13 @@ function renderers(state) {
     var mobile = state.mobile
     var signatures = state.signatures
     var digest = derived.merkle.digest
-    var menu = thunk(renderMenu, { digest: digest, mobile: mobile })
+    var menu = thunk(
+      renderMenu,
+      { digest: digest,
+        mobile: mobile,
+        form: form,
+        blanks: blanks,
+        sigantures: signatures })
     return h('article.commonform',
       [ menu,
         h('form',

--- a/renderers/markup-button.js
+++ b/renderers/markup-button.js
@@ -1,0 +1,29 @@
+module.exports = markupButton
+
+var filesaver = require('filesaver.js').saveAs
+var h = require('virtual-dom/h')
+var stringify = require('commonform-markup-stringify')
+
+function markupButton(state) {
+  console.log('state', state)
+  var form = state.form
+  return h('button',
+    { onclick: function(event) {
+        event.preventDefault()
+        var title = prompt(
+          'Enter a document title',
+          'Untitled Form')
+        if (title !== null) {
+          console.log(form)
+          console.log(stringify(form))
+          var blob = new Blob(
+            [ stringify(form) ],
+            { type: 'text/plain;charset=utf-8' })
+          filesaver(
+            blob,
+            fileName(title, 'cform')) } } },
+    [ 'Download Markup' ]) }
+
+function fileName(title, extension) {
+  var date = new Date().toISOString()
+  return ( '' + title + ' ' + date + '.' + extension ) }

--- a/renderers/menu.js
+++ b/renderers/menu.js
@@ -3,11 +3,21 @@ module.exports = menu
 var h = require('virtual-dom/h')
 var renderDOCXButton = require('./docx-button')
 var renderEMailButton = require('./e-mail-button')
+var renderMarkupButton = require('./markup-button')
 var thunk = require('vdom-thunk')
 
 function menu(state) {
+  var blanks = state.blanks
   var digest = state.digest
+  var form = state.form
   var mobile = state.mobile
+  var signatures = state.signatures
   return h('div.menu',
-    [ ( mobile ? undefined : renderDOCXButton(state) ),
-    thunk(renderEMailButton, digest) ]) }
+    [ ( mobile ? undefined :
+          renderDOCXButton(
+            { form: form,
+              blanks: blanks,
+              signatures: signatures }) ),
+      ( mobile ? undefined :
+          renderMarkupButton({ form: form }) ),
+      thunk(renderEMailButton, digest) ]) }

--- a/renderers/menu.js
+++ b/renderers/menu.js
@@ -1,7 +1,7 @@
 module.exports = menu
 
 var h = require('virtual-dom/h')
-var renderDownloadButton = require('./download-button')
+var renderDOCXButton = require('./docx-button')
 var renderEMailButton = require('./e-mail-button')
 var thunk = require('vdom-thunk')
 
@@ -9,5 +9,5 @@ function menu(state) {
   var digest = state.digest
   var mobile = state.mobile
   return h('div.menu',
-    [ ( mobile ? undefined : renderDownloadButton(state) ),
+    [ ( mobile ? undefined : renderDOCXButton(state) ),
     thunk(renderEMailButton, digest) ]) }


### PR DESCRIPTION
This PR adds a "Download Markup" button to the menu at the top and bottom of each form page. Clicking the button prompts for a document title, then downloads a copy of the current form in Common Form plain text markup format.

Inspired: commonform/help#1

cc @anseljh @tbrooke
